### PR TITLE
Add Riverpod formatter support and Cursor/Open VSX install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Because it works at the text level, it's compatible with any logging library tha
 
 Install directly from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=dawidope.flutter-log-fold) or search for **"Flutter Log Fold"** in the Extensions tab.
 
+### Cursor / Open VSX
+
+Available on [Open VSX](https://open-vsx.org/extension/dawidope/flutter-log-fold) — search for **"Flutter Log Fold"** in Cursor's Extensions tab, or install manually from a `.vsix` file via **Extensions → … → Install from VSIX**.
+
 ### From VSIX
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Built-in formatters condense verbose Talker block output into concise one-liners
 | `bloc-transition` | Multi-line block with timestamps | `[bloc-transition] MyCubit \| OldState -> NewState` |
 | `bloc-create` | Multi-line block | `[bloc-create] MyCubit` |
 | `bloc-close` | Multi-line block | `[bloc-close] MyCubit` |
+| `riverpod-add` | Multi-line block with timestamps | `[riverpod-add] MyProvider \| AsyncLoading()` |
+| `riverpod-update` | Multi-line block with timestamps | `[riverpod-update] MyProvider \| OldState -> NewState` |
+| `riverpod-dispose` | Multi-line block | `[riverpod-dispose] MyProvider` |
 | `route` | Block with timestamps | `[route] Open route named home` |
 | Other tags | Block with `\| HH:MM:SS xxxms \|` header | `[tag] message` (timestamp stripped) |
 
@@ -93,13 +96,14 @@ All settings are under the `flutterLogFold.*` namespace.
 | `blockEnd` | `"└──"` | Custom block end marker (only with `custom` preset) |
 | `blockContentPrefix` | `"│"` | Content prefix to strip (only with `custom` preset) |
 | `talkerBlocFormat` | `true` | Condense bloc-transition/create/close into one-liners |
+| `talkerRiverpodFormat` | `true` | Condense riverpod-add/update/dispose into one-liners |
 | `talkerRouteFormat` | `true` | Condense route observer blocks into one-liners |
 | `talkerStripTimestamp` | `true` | Strip Talker timestamps from other tag summaries |
 | `lineStripPattern` | `""` | Regex to strip from every line before block detection |
 
 ## Supported logging libraries
 
-- [talker](https://pub.dev/packages/talker) / [talker_flutter](https://pub.dev/packages/talker_flutter) / [talker_dio_logger](https://pub.dev/packages/talker_dio_logger)
+- [talker](https://pub.dev/packages/talker) / [talker_flutter](https://pub.dev/packages/talker_flutter) / [talker_dio_logger](https://pub.dev/packages/talker_dio_logger) / [talker_riverpod_logger](https://pub.dev/packages/talker_riverpod_logger)
 - [pretty_dio_logger](https://pub.dev/packages/pretty_dio_logger)
 - [logger](https://pub.dev/packages/logger)
 - Any custom format via the `custom` preset

--- a/package.json
+++ b/package.json
@@ -127,6 +127,11 @@
           "default": true,
           "description": "Format Talker bloc plugin blocks (bloc-transition, bloc-create, bloc-close) into concise one-line summaries."
         },
+        "flutterLogFold.talkerRiverpodFormat": {
+          "type": "boolean",
+          "default": true,
+          "description": "Format Talker Riverpod logger blocks (riverpod-add, riverpod-update, riverpod-dispose) into concise one-line summaries."
+        },
         "flutterLogFold.talkerStripTimestamp": {
           "type": "boolean",
           "default": true,

--- a/src/LogParser.ts
+++ b/src/LogParser.ts
@@ -1,6 +1,7 @@
 import { LogEntry, LogCategory, LogSource, BlockPatterns, ParserSettings, SEVERITY_LEVELS } from './types';
 import { FormatterRegistry } from './formatters/registry';
 import { blocFormatters } from './formatters/bloc';
+import { riverpodFormatters } from './formatters/riverpod';
 import { routeFormatters } from './formatters/route';
 import { talkerDefaultFormatter } from './formatters/talker-default';
 
@@ -69,6 +70,12 @@ export class LogParser {
       this.registry.register(blocFormatters);
     } else {
       this.registry.unregister(blocFormatters);
+    }
+    // Riverpod formatters
+    if (this.settings.talkerRiverpodFormat) {
+      this.registry.register(riverpodFormatters);
+    } else {
+      this.registry.unregister(riverpodFormatters);
     }
     // Route formatters
     if (this.settings.talkerRouteFormat) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,7 @@ function resolveParserSettings(): ParserSettings {
   const config = vscode.workspace.getConfiguration('flutterLogFold');
   return {
     talkerBlocFormat: config.get<boolean>('talkerBlocFormat', true),
+    talkerRiverpodFormat: config.get<boolean>('talkerRiverpodFormat', true),
     talkerRouteFormat: config.get<boolean>('talkerRouteFormat', true),
     talkerStripTimestamp: config.get<boolean>('talkerStripTimestamp', true),
     maxBlockLines: config.get<number>('maxBlockLines', 50000),

--- a/src/formatters/riverpod.ts
+++ b/src/formatters/riverpod.ts
@@ -1,0 +1,55 @@
+import { BlockFormatter } from './registry';
+
+export const riverpodFormatters: Record<string, BlockFormatter> = {
+  'riverpod-update': (lines) => {
+    // Lines[0]: [riverpod-update] | HH:MM:SS ... |
+    // Lines[1]: X updated
+    // Lines[2]: PREVIOUS state:
+    // Lines[3]: prev-value (possibly multi-line — take first line only)
+    // ...
+    // Lines[N]: NEW state:
+    // Lines[N+1]: new-value (possibly multi-line — take first line only)
+    if (lines.length < 5) { return null; }
+    const nameMatch = lines[1]?.trim().match(/^(.+?)\s+updated$/);
+    if (!nameMatch) { return null; }
+    const prevLabel = lines[2]?.trim();
+    if (prevLabel !== 'PREVIOUS state:') { return null; }
+    const prevValue = lines[3]?.trim();
+    if (!prevValue) { return null; }
+    // Find "NEW state:" line
+    let newStateIdx = -1;
+    for (let i = 4; i < lines.length; i++) {
+      if (lines[i].trim() === 'NEW state:') {
+        newStateIdx = i;
+        break;
+      }
+    }
+    if (newStateIdx === -1 || newStateIdx + 1 >= lines.length) { return null; }
+    const newValue = lines[newStateIdx + 1]?.trim();
+    if (!newValue) { return null; }
+    return `[riverpod-update] ${nameMatch[1]} | ${prevValue} -> ${newValue}`;
+  },
+
+  'riverpod-add': (lines) => {
+    // Lines[0]: [riverpod-add] | HH:MM:SS ... |
+    // Lines[1]: X initialized
+    // Lines[2]: INITIAL state:
+    // Lines[3]: state value (possibly multi-line — take first line only)
+    if (lines.length < 4) { return null; }
+    const nameMatch = lines[1]?.trim().match(/^(.+?)\s+initialized$/);
+    if (!nameMatch) { return null; }
+    const label = lines[2]?.trim();
+    if (label !== 'INITIAL state:') { return null; }
+    const stateValue = lines[3]?.trim();
+    if (!stateValue) { return null; }
+    return `[riverpod-add] ${nameMatch[1]} | ${stateValue}`;
+  },
+
+  'riverpod-dispose': (lines) => {
+    // Lines[0]: [riverpod-dispose] | HH:MM:SS ... |
+    // Lines[1]: X disposed
+    if (lines.length < 2) { return null; }
+    const name = lines[1]?.trim().replace(/\s+disposed$/, '');
+    return name ? `[riverpod-dispose] ${name}` : null;
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface LogEntry {
 
 export interface ParserSettings {
   talkerBlocFormat: boolean;
+  talkerRiverpodFormat: boolean;
   talkerRouteFormat: boolean;
   talkerStripTimestamp: boolean;
   maxBlockLines: number;

--- a/test/LogParser.test.ts
+++ b/test/LogParser.test.ts
@@ -11,6 +11,7 @@ const PRETTY: BlockPatterns = PRESETS.pretty;
 
 const DEFAULT_SETTINGS: ParserSettings = {
   talkerBlocFormat: true,
+  talkerRiverpodFormat: true,
   talkerRouteFormat: true,
   talkerStripTimestamp: true,
   maxBlockLines: 50_000,
@@ -373,6 +374,31 @@ describe('platform fixtures', () => {
     entries.forEach((e) => expect(e.type).toBe('talker-block'));
     expect(entries[0].summary).toBe('Request: GET https://api.example.com/users');
     expect(entries[1].summary).toBe('Response: 200 OK');
+  });
+});
+
+// ── 8b. Riverpod fixture (end-to-end) ─────────────────────────────────
+
+describe('riverpod fixture', () => {
+  it('all blocks parsed with correct formatted summaries', () => {
+    const { entries, parser } = collect();
+    parser.processOutput(fixture('riverpod.txt'));
+
+    expect(entries).toHaveLength(3);
+    entries.forEach((e) => {
+      expect(e.type).toBe('talker-block');
+      expect(e.formattedSummary).toBe(true);
+    });
+
+    expect(entries[0].summary).toBe(
+      '[riverpod-add] FutureProvider<Repository> | AsyncLoading<Repository>()',
+    );
+    expect(entries[1].summary).toBe(
+      "[riverpod-update] FutureProvider<Repository> | AsyncLoading<Repository>() -> AsyncData<Repository>(value: Instance of 'Repository')",
+    );
+    expect(entries[2].summary).toBe(
+      '[riverpod-dispose] FutureProvider<Repository>',
+    );
   });
 });
 

--- a/test/fixtures/riverpod.txt
+++ b/test/fixtures/riverpod.txt
@@ -1,0 +1,18 @@
+┌──────────────────────────────────────
+│ [riverpod-add] | 17:15:20 887ms |
+│ FutureProvider<Repository> initialized
+│ INITIAL state:
+│ AsyncLoading<Repository>()
+└──────────────────────────────────────
+┌──────────────────────────────────────
+│ [riverpod-update] | 17:15:20 898ms |
+│ FutureProvider<Repository> updated
+│ PREVIOUS state:
+│ AsyncLoading<Repository>()
+│ NEW state:
+│ AsyncData<Repository>(value: Instance of 'Repository')
+└──────────────────────────────────────
+┌──────────────────────────────────────
+│ [riverpod-dispose] | 17:15:22 378ms |
+│ FutureProvider<Repository> disposed
+└──────────────────────────────────────

--- a/test/formatters.test.ts
+++ b/test/formatters.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { FormatterRegistry, BlockFormatter } from '../src/formatters/registry';
 import { blocFormatters } from '../src/formatters/bloc';
+import { riverpodFormatters } from '../src/formatters/riverpod';
 import { routeFormatters } from '../src/formatters/route';
 import { talkerDefaultFormatter } from '../src/formatters/talker-default';
 
@@ -126,6 +127,113 @@ describe('bloc-close formatter', () => {
 
   it('returns null for too few lines', () => {
     expect(format(['[bloc-close] | 10:00:00 1ms |'])).toBeNull();
+  });
+});
+
+// ── riverpod-update ──────────────────────────────────────────────────
+
+describe('riverpod-update formatter', () => {
+  const format = riverpodFormatters['riverpod-update'];
+
+  it('formats update block correctly', () => {
+    const lines = [
+      '[riverpod-update] | 17:15:20 898ms |',
+      'FutureProvider<Repository> updated',
+      'PREVIOUS state:',
+      'AsyncLoading<Repository>()',
+      'NEW state:',
+      "AsyncData<Repository>(value: Instance of 'Repository')",
+    ];
+    expect(format(lines)).toBe(
+      "[riverpod-update] FutureProvider<Repository> | AsyncLoading<Repository>() -> AsyncData<Repository>(value: Instance of 'Repository')",
+    );
+  });
+
+  it('handles multi-line state values (takes first line only)', () => {
+    const lines = [
+      '[riverpod-update] | 17:15:20 898ms |',
+      'SomeProvider updated',
+      'PREVIOUS state:',
+      'OldState(',
+      '  field: value,',
+      ')',
+      'NEW state:',
+      'NewState(',
+      '  field: value,',
+      ')',
+    ];
+    expect(format(lines)).toBe(
+      '[riverpod-update] SomeProvider | OldState( -> NewState(',
+    );
+  });
+
+  it('returns null for too few lines', () => {
+    expect(format(['[riverpod-update] | 17:00:00 1ms |'])).toBeNull();
+    expect(format(['header', 'X updated', 'PREVIOUS state:', 'A'])).toBeNull();
+  });
+
+  it('returns null for malformed lines', () => {
+    const lines = [
+      '[riverpod-update] | 17:00:00 1ms |',
+      'not a valid updated line',
+      'PREVIOUS state:',
+      'A',
+      'NEW state:',
+      'B',
+    ];
+    expect(format(lines)).toBeNull();
+  });
+});
+
+// ── riverpod-add ─────────────────────────────────────────────────────
+
+describe('riverpod-add formatter', () => {
+  const format = riverpodFormatters['riverpod-add'];
+
+  it('formats add block correctly', () => {
+    const lines = [
+      '[riverpod-add] | 17:15:20 887ms |',
+      'FutureProvider<Repository> initialized',
+      'INITIAL state:',
+      'AsyncLoading<Repository>()',
+    ];
+    expect(format(lines)).toBe(
+      '[riverpod-add] FutureProvider<Repository> | AsyncLoading<Repository>()',
+    );
+  });
+
+  it('returns null for too few lines', () => {
+    expect(format(['[riverpod-add] | 17:00:00 1ms |'])).toBeNull();
+    expect(format(['header', 'X initialized'])).toBeNull();
+    expect(format(['header', 'X initialized', 'INITIAL state:'])).toBeNull();
+  });
+
+  it('returns null for malformed lines', () => {
+    const lines = [
+      '[riverpod-add] | 17:00:00 1ms |',
+      'not a valid initialized line',
+      'INITIAL state:',
+      'SomeState()',
+    ];
+    expect(format(lines)).toBeNull();
+  });
+});
+
+// ── riverpod-dispose ─────────────────────────────────────────────────
+
+describe('riverpod-dispose formatter', () => {
+  const format = riverpodFormatters['riverpod-dispose'];
+
+  it('formats dispose block correctly', () => {
+    const lines = [
+      '[riverpod-dispose] | 17:15:22 378ms |',
+      'FutureProvider<Repository> disposed',
+    ];
+    expect(format(lines)).toBe('[riverpod-dispose] FutureProvider<Repository>');
+  });
+
+  it('returns null for too few lines', () => {
+    expect(format(['[riverpod-dispose] | 17:00:00 1ms |'])).toBeNull();
   });
 });
 


### PR DESCRIPTION
Add riverpod-add, riverpod-update, riverpod-dispose formatters mirroring the existing bloc formatters for talker_riverpod_logger output. Add talkerRiverpodFormat setting (default: true).
Document Cursor / Open VSX installation in README.