### PR TITLE
Add command-based trace sessions with stop control

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Full ANSI color rendering — 8-color, bright, 256-color palette, and RGB — us
 ### Other
 
 - **Auto-open** — log panel opens automatically when a Flutter debug session starts
+- **Terminal commands** — run editable `flutter run` or `flutter logs` commands from the Command Palette and keep the output flowing into the log panel
+- **Trace stop control** — when logs are coming from those terminal commands, a `Stop` button appears in the toolbar to end tracking and stop the process
 - **Timestamps** — HH:MM:SS.mmm on every block entry
 - **Smart auto-scroll** — stays at bottom for new logs, but respects manual scroll position
 - **Collapse All / Expand All** — toolbar buttons to fold/unfold all blocks at once
@@ -77,6 +79,8 @@ Full ANSI color rendering — 8-color, bright, 256-color palette, and RGB — us
 |---------|-------------|
 | `Flutter Logs: Show Panel` | Open / focus the log panel |
 | `Flutter Logs: Clear` | Clear all logs |
+| `Flutter Logs: Run Flutter Command...` | Open an editable `flutter` command prompt, run it in a pseudoterminal, and stream logs into the panel |
+| `Flutter Logs: Tail Flutter Logs...` | Open an editable `flutter logs` prompt, run it in a pseudoterminal, and stream logs into the panel |
 
 ## Settings
 
@@ -96,6 +100,8 @@ All settings are under the `flutterLogFold.*` namespace.
 | `talkerRouteFormat` | `true` | Condense route observer blocks into one-liners |
 | `talkerStripTimestamp` | `true` | Strip Talker timestamps from other tag summaries |
 | `lineStripPattern` | `""` | Regex to strip from every line before block detection |
+| `runCommandDefault` | `"flutter run --debug"` | Default text shown for the editable Flutter run command prompt |
+| `tailCommandDefault` | `"flutter logs"` | Default text shown for the editable Flutter logs command prompt |
 
 ## Supported logging libraries
 
@@ -106,7 +112,7 @@ All settings are under the `flutterLogFold.*` namespace.
 
 ## How it works
 
-The extension reads the raw text output from Flutter's Debug Console — the same stream you see in VS Code's built-in terminal. No SDK integration, no custom log drivers, no code changes in your app. It subscribes to `vscode.debug.onDidReceiveDebugSessionCustomEvent` and parses every line as plain text.
+The extension reads the raw text output from Flutter debug sessions and from extension-owned pseudoterminals — no SDK integration, no custom log drivers, no code changes in your app. It uses the Dart debug adapter tracker for normal debug runs, and the two Command Palette commands for terminal-based runs.
 
 Platform-specific prefixes are stripped automatically:
 - **Android** — `I/flutter ( PID): ` (from `adb logcat`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flutter-log-fold",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flutter-log-fold",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.19.33",
@@ -1387,7 +1387,6 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4960,7 +4959,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5740,7 +5738,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,14 @@
       {
         "command": "flutterLogFold.clear",
         "title": "Flutter Logs: Clear"
+      },
+      {
+        "command": "flutterLogFold.runFlutterCommand",
+        "title": "Flutter Logs: Run Flutter Command..."
+      },
+      {
+        "command": "flutterLogFold.tailFlutterLogs",
+        "title": "Flutter Logs: Tail Flutter Logs..."
       }
     ],
     "configuration": {
@@ -141,6 +149,16 @@
           "type": "string",
           "default": "",
           "description": "Optional regex applied to every line before block detection. Use to strip process prefixes, e.g. ^[A-Z]/[\\w.]+\\(\\d+\\):\\s? removes 'I/flutter (PID): '. Empty = disabled."
+        },
+        "flutterLogFold.runCommandDefault": {
+          "type": "string",
+          "default": "flutter run --debug",
+          "description": "Default text shown when starting the editable Flutter run command prompt."
+        },
+        "flutterLogFold.tailCommandDefault": {
+          "type": "string",
+          "default": "flutter logs",
+          "description": "Default text shown when starting the editable Flutter logs command prompt."
         }
       }
     }

--- a/src/LogPanelProvider.ts
+++ b/src/LogPanelProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import { LogEntry, ExtensionToWebviewMessage } from './types';
+import { LogEntry, ExtensionToWebviewMessage, WebviewToExtensionMessage } from './types';
 
 export class LogPanelProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'flutterLogFold.logView';
@@ -12,6 +12,9 @@ export class LogPanelProvider implements vscode.WebviewViewProvider {
   private readonly extensionUri: vscode.Uri;
   private knownTagsGetter?: () => string[];
   private viewDisposables: vscode.Disposable[] = [];
+  private tracingActive = false;
+  private tracingDescription = '';
+  private stopTracingHandler?: () => void;
 
   constructor(extensionUri: vscode.Uri) {
     this.extensionUri = extensionUri;
@@ -22,6 +25,22 @@ export class LogPanelProvider implements vscode.WebviewViewProvider {
 
   setKnownTagsGetter(getter: () => string[]): void {
     this.knownTagsGetter = getter;
+  }
+
+  setStopTracingHandler(handler: () => void): void {
+    this.stopTracingHandler = handler;
+  }
+
+  setTraceState(active: boolean, description = ''): void {
+    this.tracingActive = active;
+    this.tracingDescription = description;
+    this.postMessage({
+      command: 'settings',
+      collapseByDefault: this.collapseByDefault,
+      maxLogs: this.maxLogs,
+      tracingActive: this.tracingActive,
+      tracingDescription: this.tracingDescription,
+    });
   }
 
   resolveWebviewView(
@@ -46,20 +65,35 @@ export class LogPanelProvider implements vscode.WebviewViewProvider {
     this.viewDisposables.push(webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible && this.buffer.length > 0) {
         this.postMessage({ command: 'batch', entries: this.buffer, knownTags: this.knownTagsGetter?.() });
-        this.postMessage({ command: 'settings', collapseByDefault: this.collapseByDefault, maxLogs: this.maxLogs });
+        this.postMessage({
+          command: 'settings',
+          collapseByDefault: this.collapseByDefault,
+          maxLogs: this.maxLogs,
+          tracingActive: this.tracingActive,
+          tracingDescription: this.tracingDescription,
+        });
       }
     }));
 
     // Handle messages from webview
-    this.viewDisposables.push(webviewView.webview.onDidReceiveMessage((message) => {
+    this.viewDisposables.push(webviewView.webview.onDidReceiveMessage((message: WebviewToExtensionMessage) => {
       if (message.command === 'ready') {
-        this.postMessage({ command: 'settings', collapseByDefault: this.collapseByDefault, maxLogs: this.maxLogs });
+        this.postMessage({
+          command: 'settings',
+          collapseByDefault: this.collapseByDefault,
+          maxLogs: this.maxLogs,
+          tracingActive: this.tracingActive,
+          tracingDescription: this.tracingDescription,
+        });
         if (this.buffer.length > 0) {
           this.postMessage({ command: 'batch', entries: this.buffer, knownTags: this.knownTagsGetter?.() });
         }
       }
       if (message.command === 'clear') {
         this.buffer = [];
+      }
+      if (message.command === 'stopTracing') {
+        this.stopTracingHandler?.();
       }
     }));
 
@@ -97,7 +131,13 @@ export class LogPanelProvider implements vscode.WebviewViewProvider {
       this.buffer.shift();
     }
 
-    this.postMessage({ command: 'settings', collapseByDefault: this.collapseByDefault, maxLogs: this.maxLogs });
+    this.postMessage({
+      command: 'settings',
+      collapseByDefault: this.collapseByDefault,
+      maxLogs: this.maxLogs,
+      tracingActive: this.tracingActive,
+      tracingDescription: this.tracingDescription,
+    });
   }
 
   private postMessage(message: ExtensionToWebviewMessage): void {
@@ -130,6 +170,7 @@ export class LogPanelProvider implements vscode.WebviewViewProvider {
       <button id="btn-collapse" title="Collapse all blocks">Collapse All</button>
       <button id="btn-expand" title="Expand all blocks">Expand All</button>
       <input type="text" id="input-filter" placeholder="Filter..." title="Filter logs by text (case-insensitive)" aria-label="Filter logs">
+      <button id="btn-stop-trace" class="trace-stop hidden" title="Stop tracking the flutter run/logs command">Stop</button>
       <span id="counter" class="counter">0 / 0</span>
     </div>
     <div class="chip-bar" id="chip-bar">

--- a/src/commandLineParser.ts
+++ b/src/commandLineParser.ts
@@ -1,0 +1,95 @@
+export interface ParsedCommand {
+  executable: string;
+  args: string[];
+  commandLine: string;
+}
+
+export function parseCommandLine(command: string): ParsedCommand | undefined {
+  const tokens = tokenizeCommandLine(command.trim());
+  if (tokens.length === 0) {
+    return undefined;
+  }
+
+  if (isFlutterExecutable(tokens[0])) {
+    tokens.shift();
+    return {
+      executable: 'flutter',
+      args: tokens,
+      commandLine: ['flutter', ...tokens].join(' '),
+    };
+  }
+
+  const [executable, ...args] = tokens;
+  return {
+    executable,
+    args,
+    commandLine: [executable, ...args].join(' '),
+  };
+}
+
+function tokenizeCommandLine(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | '\'' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+
+    if (character === '\\') {
+      const nextCharacter = command[index + 1];
+      if (nextCharacter && (nextCharacter === '"' || nextCharacter === '\'' || nextCharacter === '\\' || /\s/.test(nextCharacter))) {
+        escaped = true;
+        continue;
+      }
+
+      current += character;
+      continue;
+    }
+
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+
+      continue;
+    }
+
+    if (character === '"' || character === '\'') {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (escaped) {
+    current += '\\';
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+function isFlutterExecutable(token: string): boolean {
+  return /^flutter(?:\.(?:bat|cmd|exe))?$/i.test(token);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 import { LogParser } from './LogParser';
 import { LogPanelProvider } from './LogPanelProvider';
+import { FlutterTraceSession, promptAndRunFlutterCommand } from './flutterCommandRunner';
 import { BlockPatterns, ParserSettings, PRESETS } from './types';
 
 let panelProvider: LogPanelProvider;
 let parser: LogParser;
+let activeTraceSession: FlutterTraceSession | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
   panelProvider = new LogPanelProvider(context.extensionUri);
@@ -16,6 +18,9 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   panelProvider.setKnownTagsGetter(() => parser.getKnownTags());
+  panelProvider.setStopTracingHandler(() => {
+    stopActiveTraceSession();
+  });
 
   // Register webview provider
   context.subscriptions.push(
@@ -32,6 +37,42 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('flutterLogFold.clear', () => {
       panelProvider.clearAll();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('flutterLogFold.runFlutterCommand', async () => {
+      const config = vscode.workspace.getConfiguration('flutterLogFold');
+      const defaultCommand = config.get<string>('runCommandDefault', 'flutter run --debug');
+      const session = await promptAndRunFlutterCommand({
+        title: 'Flutter Logs: Run Flutter Command',
+        defaultCommand,
+        placeholder: 'flutter run --flavor staging --dart-define=API_URL=https://...',
+        onOutput: (text) => parser.processOutput(text),
+        cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+      });
+
+      if (session) {
+        attachTraceSession(session);
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('flutterLogFold.tailFlutterLogs', async () => {
+      const config = vscode.workspace.getConfiguration('flutterLogFold');
+      const defaultCommand = config.get<string>('tailCommandDefault', 'flutter logs');
+      const session = await promptAndRunFlutterCommand({
+        title: 'Flutter Logs: Tail Flutter Logs',
+        defaultCommand,
+        placeholder: 'flutter logs --device-id emulator-5554',
+        onOutput: (text) => parser.processOutput(text),
+        cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+      });
+
+      if (session) {
+        attachTraceSession(session);
+      }
     })
   );
 
@@ -77,6 +118,29 @@ export function activate(context: vscode.ExtensionContext) {
   );
 }
 
+function attachTraceSession(session: FlutterTraceSession): void {
+  stopActiveTraceSession();
+  activeTraceSession = session;
+  panelProvider.setTraceState(true, `Stop tracking command: ${session.commandLine}`);
+
+  session.onDidStop(() => {
+    if (activeTraceSession === session) {
+      activeTraceSession = undefined;
+      panelProvider.setTraceState(false);
+    }
+  });
+}
+
+function stopActiveTraceSession(): void {
+  if (!activeTraceSession) {
+    return;
+  }
+
+  activeTraceSession.stop();
+  activeTraceSession = undefined;
+  panelProvider.setTraceState(false);
+}
+
 function resolvePatterns(): BlockPatterns {
   const config = vscode.workspace.getConfiguration('flutterLogFold');
   const preset = config.get<string>('preset', 'talker');
@@ -109,5 +173,6 @@ function resolveParserSettings(): ParserSettings {
 
 export function deactivate() {
   // Parser flush on deactivation
+  stopActiveTraceSession();
   parser?.flush();
 }

--- a/src/flutterCommandRunner.ts
+++ b/src/flutterCommandRunner.ts
@@ -1,0 +1,206 @@
+import * as vscode from 'vscode';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { parseCommandLine } from './commandLineParser';
+
+export interface FlutterCommandRunnerOptions {
+  title: string;
+  defaultCommand: string;
+  placeholder: string;
+  onOutput: (text: string) => void;
+  cwd?: string;
+}
+
+export interface FlutterTraceSession extends vscode.Disposable {
+  readonly commandLine: string;
+  readonly onDidStop: vscode.Event<void>;
+  stop(): void;
+}
+
+export async function promptAndRunFlutterCommand(options: FlutterCommandRunnerOptions): Promise<FlutterTraceSession | undefined> {
+  const command = await vscode.window.showInputBox({
+    prompt: 'Edit the command then press Enter to run',
+    value: options.defaultCommand,
+    placeHolder: options.placeholder,
+  });
+
+  if (!command) {
+    return undefined;
+  }
+
+  const parsed = parseCommandLine(command);
+  if (!parsed) {
+    return undefined;
+  }
+
+  const pty = new FlutterCommandPseudoterminal(parsed.executable, parsed.args, options.onOutput, options.cwd);
+  const terminal = vscode.window.createTerminal({ name: options.title, pty });
+  const session = new FlutterTraceSessionImpl(parsed.commandLine, terminal, pty);
+  terminal.show(true);
+  return session;
+}
+
+class FlutterCommandPseudoterminal implements vscode.Pseudoterminal, vscode.Disposable {
+  private readonly writeEmitter = new vscode.EventEmitter<string>();
+  private readonly closeEmitter = new vscode.EventEmitter<number | void>();
+  private childProcess?: ChildProcessWithoutNullStreams;
+  private childPid?: number;
+  private parserBuffer = '';
+  private disposed = false;
+  private hasClosed = false;
+
+  public readonly onDidWrite = this.writeEmitter.event;
+  public readonly onDidClose = this.closeEmitter.event;
+
+  constructor(
+    private readonly executable: string,
+    private readonly args: string[],
+    private readonly onOutput: (text: string) => void,
+    private readonly cwd?: string,
+  ) {}
+
+  open(): void {
+    this.writeEmitter.fire(`> ${this.executable} ${this.args.join(' ')}\r\n`);
+
+    this.childProcess = spawn(this.executable, this.args, {
+      cwd: this.cwd,
+      env: { ...process.env },
+      shell: true,
+    });
+
+    this.childPid = this.childProcess.pid;
+
+    this.childProcess.stdout.setEncoding('utf8');
+    this.childProcess.stderr.setEncoding('utf8');
+
+    this.childProcess.stdout.on('data', (data: string) => this.forwardOutput(data));
+    this.childProcess.stderr.on('data', (data: string) => this.forwardOutput(data));
+
+    this.childProcess.on('error', (error) => {
+      this.writeEmitter.fire(`\r\n[flutter-log-fold] failed to start ${this.executable}: ${error.message}\r\n`);
+      this.finish(1, true);
+    });
+
+    this.childProcess.on('close', (code) => {
+      this.flushParserBuffer();
+      this.finish(code ?? undefined, true);
+    });
+  }
+
+  handleInput(data: string): void {
+    if (!this.childProcess?.stdin.writable) {
+      return;
+    }
+
+    if (data === '\u0003') {
+      this.terminateProcessTree();
+      return;
+    }
+
+    this.childProcess.stdin.write(data);
+  }
+
+  close(): void {
+    this.disposed = true;
+    this.terminateProcessTree();
+    this.flushParserBuffer();
+    this.finish(undefined, false);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.terminateProcessTree();
+    this.flushParserBuffer();
+    this.finish(undefined, false);
+    this.writeEmitter.dispose();
+    this.closeEmitter.dispose();
+  }
+
+  private forwardOutput(data: string): void {
+    this.writeEmitter.fire(data);
+    this.parserBuffer += data.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+    let newlineIndex = this.parserBuffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const chunk = this.parserBuffer.slice(0, newlineIndex + 1);
+      this.onOutput(chunk);
+      this.parserBuffer = this.parserBuffer.slice(newlineIndex + 1);
+      newlineIndex = this.parserBuffer.indexOf('\n');
+    }
+  }
+
+  private flushParserBuffer(): void {
+    if (this.parserBuffer.length > 0) {
+      this.onOutput(this.parserBuffer);
+      this.parserBuffer = '';
+    }
+  }
+
+  private finish(exitCode: number | undefined, emitTerminalMessage: boolean): void {
+    if (this.hasClosed) {
+      return;
+    }
+
+    this.hasClosed = true;
+    if (emitTerminalMessage && !this.disposed) {
+      this.writeEmitter.fire(`\r\n[flutter-log-fold] process exited with code ${exitCode ?? 'unknown'}\r\n`);
+    }
+    this.closeEmitter.fire(exitCode);
+  }
+
+  private terminateProcessTree(): void {
+    const pid = this.childPid;
+    if (!pid) {
+      return;
+    }
+
+    if (process.platform === 'win32') {
+      const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { windowsHide: true });
+      killer.on('error', () => {
+        this.childProcess?.kill();
+      });
+      return;
+    }
+
+    this.childProcess?.kill('SIGTERM');
+  }
+}
+
+class FlutterTraceSessionImpl implements FlutterTraceSession {
+  private readonly stopEmitter = new vscode.EventEmitter<void>();
+  private disposed = false;
+
+  public readonly onDidStop = this.stopEmitter.event;
+
+  constructor(
+    public readonly commandLine: string,
+    private readonly terminal: vscode.Terminal,
+    private readonly pty: FlutterCommandPseudoterminal,
+  ) {
+    this.pty.onDidClose(() => {
+      if (this.disposed) {
+        return;
+      }
+
+      this.disposed = true;
+      this.stopEmitter.fire();
+      this.dispose();
+    });
+  }
+
+  stop(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
+    this.terminal.dispose();
+    this.stopEmitter.fire();
+    this.dispose();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.pty.dispose();
+    this.stopEmitter.dispose();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,10 +35,12 @@ export interface ExtensionToWebviewMessage {
   knownTags?: string[];
   collapseByDefault?: boolean;
   maxLogs?: number;
+  tracingActive?: boolean;
+  tracingDescription?: string;
 }
 
 export interface WebviewToExtensionMessage {
-  command: 'clear' | 'ready';
+  command: 'clear' | 'ready' | 'stopTracing';
 }
 
 export const PRESETS: Record<string, BlockPatterns> = {

--- a/test/flutterCommandRunner.test.ts
+++ b/test/flutterCommandRunner.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseCommandLine } from '../src/commandLineParser';
+
+describe('parseCommandLine', () => {
+  it('strips a leading flutter executable', () => {
+    expect(parseCommandLine('flutter run --debug')).toEqual({
+      executable: 'flutter',
+      args: ['run', '--debug'],
+      commandLine: 'flutter run --debug',
+    });
+  });
+
+  it('keeps quoted arguments intact', () => {
+    expect(parseCommandLine('flutter run --dart-define="API_URL=https://example.com/api v1"')).toEqual({
+      executable: 'flutter',
+      args: ['run', '--dart-define=API_URL=https://example.com/api v1'],
+      commandLine: 'flutter run --dart-define=API_URL=https://example.com/api v1',
+    });
+  });
+
+  it('preserves non-flutter prefixes', () => {
+    expect(parseCommandLine('dart run tool.dart')).toEqual({
+      executable: 'dart',
+      args: ['run', 'tool.dart'],
+      commandLine: 'dart run tool.dart',
+    });
+  });
+});

--- a/webview/main.js
+++ b/webview/main.js
@@ -11,6 +11,7 @@
   const btnClear = /** @type {HTMLElement} */ (document.getElementById('btn-clear'));
   const btnCollapse = /** @type {HTMLElement} */ (document.getElementById('btn-collapse'));
   const btnExpand = /** @type {HTMLElement} */ (document.getElementById('btn-expand'));
+  const btnStopTrace = /** @type {HTMLElement} */ (document.getElementById('btn-stop-trace'));
   const chipSystem = /** @type {HTMLElement} */ (document.getElementById('chip-system'));
   const chipSeparator = /** @type {HTMLElement} */ (document.getElementById('chip-separator'));
 
@@ -252,6 +253,7 @@
         if (message.maxLogs !== undefined) {
           maxLogs = message.maxLogs;
         }
+        updateTraceButton(message.tracingActive, message.tracingDescription);
         break;
     }
   });
@@ -269,6 +271,10 @@
 
   btnExpand.addEventListener('click', () => {
     container.querySelectorAll('details:not([open])').forEach((d) => d.setAttribute('open', ''));
+  });
+
+  btnStopTrace.addEventListener('click', () => {
+    vscode.postMessage({ command: 'stopTracing' });
   });
 
   filterInput.addEventListener('input', () => {
@@ -558,6 +564,21 @@
     if (userAtBottom) {
       container.scrollTop = container.scrollHeight;
     }
+  }
+
+  /**
+   * @param {boolean|undefined} tracingActive
+   * @param {string|undefined} tracingDescription
+   */
+  function updateTraceButton(tracingActive, tracingDescription) {
+    if (tracingActive) {
+      btnStopTrace.classList.remove('hidden');
+      btnStopTrace.title = tracingDescription || 'Stop tracking the flutter run/logs command';
+      return;
+    }
+
+    btnStopTrace.classList.add('hidden');
+    btnStopTrace.title = 'Stop tracking the flutter run/logs command';
   }
 
   // ── JSON detection & rendering ──

--- a/webview/style.css
+++ b/webview/style.css
@@ -54,6 +54,19 @@ body {
   background: var(--vscode-button-hoverBackground);
 }
 
+.trace-stop {
+  background: var(--vscode-inputValidation-warningBackground, #5a4a1d) !important;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-editorWarning-foreground, #cca700)) !important;
+}
+
+.trace-stop:hover {
+  background: var(--vscode-button-hoverBackground) !important;
+}
+
+.hidden {
+  display: none !important;
+}
+
 #input-filter {
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);


### PR DESCRIPTION
Introduce command-based trace sessions implementing your [wrapped psuedo terminal](https://github.com/dawidope/flutter-log-fold/issues/4#issuecomment-4497937034) suggestion in #4 allowing users to start and stop tracing logs. Also enhance the command line parser with tests to ensure proper behavior.